### PR TITLE
Denial to tightness

### DIFF
--- a/process_globals.py
+++ b/process_globals.py
@@ -34,11 +34,11 @@ INQUIRY_INDEX_OUTPUT_SCHEMA = [
     "inquiry_rate",
     "unadjusted_inquiry_rate"
 ]
-DENIAL_INDEX_OUTPUT_SCHEMA = [
+TIGHTNESS_INDEX_OUTPUT_SCHEMA = [
     "month",
     "date",
-    "inferred_denial_rate",
-    "unadjusted_inferred_denial_rate"
+    "credit tightness_rate",
+    "unadjusted_credit_tightness_rate"
 ]
 
 # Input/output schemas

--- a/process_globals.py
+++ b/process_globals.py
@@ -17,7 +17,6 @@ DEFAULT_OUTPUT_FOLDER = "~/Github/consumer-credit-trends-data/processed_data/"
 # Filenames for non-market-specific files:
 # Data snapshot, inquiry index
 SNAPSHOT_FNAME_KEY = "data_snapshot"
-INQUIRY_INDEX_FNAME_KEY = "main_inquiry_series"
 
 # Text descriptors for data snapshots
 PERCENT_CHANGE_DESCRIPTORS = ["decrease", "increase"]
@@ -31,14 +30,14 @@ SNAPSHOT_DATE_SCHEMA = "%Y-%m-%d"
 INQUIRY_INDEX_OUTPUT_SCHEMA = [
     "month",
     "date",
-    "inquiry_rate",
-    "unadjusted_inquiry_rate"
+    "inquiry_index",
+    "unadjusted_inquiry_index"
 ]
 TIGHTNESS_INDEX_OUTPUT_SCHEMA = [
     "month",
     "date",
-    "credit tightness_rate",
-    "unadjusted_credit_tightness_rate"
+    "tightness_index",
+    "unadjusted_credit_tightness_index"
 ]
 
 # Input/output schemas

--- a/process_incoming_data.py
+++ b/process_incoming_data.py
@@ -144,33 +144,6 @@ def process_data_files(inputpath,
 
                 successes.append(filename)
 
-            # Look for inquiry index summary files
-            elif cfg.INQUIRY_INDEX_FNAME_KEY in filename:
-                logger.debug(
-                    "Processing inquiry index file '{}'".format(filename)
-                )
-                cond, databymkt, jsonbymkt = process_inquiry_index(filepath)
-
-                if cond:
-                    for mkt in databymkt:
-                        # Determine output directory
-                        outpath = os.path.join(
-                            outputpath,
-                            cfg.MARKET_NAMES[mkt],
-                            "inquiry_rate_{}.csv".format(mkt)
-                        )
-
-                        if len(databymkt[mkt]) > 0:
-                            util.save_csv(outpath, databymkt[mkt])
-                            util.save_json(
-                                outpath.replace(".csv", ".json"),
-                                jsonbymkt[mkt]
-                            )
-
-                    successes.append(filename)
-                else:
-                    failures.append(filename)
-
             # Doesn't match an expected filename; may not be a CCT file
             else:
                 logger.info(
@@ -790,8 +763,8 @@ def process_data_snapshot(filepath, date_schema=cfg.SNAPSHOT_DATE_SCHEMA):
             yoy_desc = cfg.PERCENT_CHANGE_DESCRIPTORS[yoy > 0]
             yoy_fmt = "{}% {}".format(yoy_num, yoy_desc)
 
-            market_info[market]["denial_yoy_change"] = yoy_fmt
-            market_info[market]["denial_month"] = month
+            market_info[market]["tightness_yoy_change"] = yoy_fmt
+            market_info[market]["tightness_month"] = month
 
         else:
             msg = "Data snapshot row (below) contains unknown " + \

--- a/process_incoming_data.py
+++ b/process_incoming_data.py
@@ -252,12 +252,12 @@ def process_inquiry_index(filename):
     return process_file_summary(filename, cfg.INQUIRY_INDEX_OUTPUT_SCHEMA)
 
 
-# Process inferred denial index file
-def process_denial_index(filename):
-    """Processes specified inferred denial file and
+# Process inferred credit tightness index file
+def process_tightness_index(filename):
+    """Processes specified credit tightness file and
     returns output data and json per the output_schema"""
-    logger.debug("Running process_denial_index")
-    return process_file_summary(filename, cfg.DENIAL_INDEX_OUTPUT_SCHEMA)
+    logger.debug("Running process_tightness_index")
+    return process_file_summary(filename, cfg.TIGHTNESS_INDEX_OUTPUT_SCHEMA)
 
 
 # Process summary files with loan numbers or volumes
@@ -563,10 +563,10 @@ def process_yoy_summary(filename, output_schema=cfg.YOY_SUMMARY_OUTPUT_SCHEMA):
         elif "volume" in type_str.lower():
             proc[monthnum]["vol"] = value
         elif "inquiry" in type_str.lower():
-            # Ignore 'Inquiry Rate' entries in current output
+            # Ignore 'Inquiry Index' entries in current output
             pass
-        elif "denial" in type_str.lower():
-            # Ignore 'Denial Rate' entries in current output
+        elif "tightness" in type_str.lower():
+            # Ignore 'Credit Tightness Index' entries in current output
             pass
         else:
             msg = "YOY Summary Data row (below) improperly " + \
@@ -784,7 +784,7 @@ def process_data_snapshot(filepath, date_schema=cfg.SNAPSHOT_DATE_SCHEMA):
             market_info[market]["inquiry_yoy_change"] = yoy_fmt
             market_info[market]["inquiry_month"] = month
 
-        elif "denial" in var_name:
+        elif "tightness" in var_name:
             yoy = float(value_yoy)
             yoy_num = "{:.1f}".format(abs(yoy))
             yoy_desc = cfg.PERCENT_CHANGE_DESCRIPTORS[yoy > 0]
@@ -818,7 +818,7 @@ FILE_PREFIXES = {"map_data":                 process_map,
                  "yoy_data_income_level":    process_group_income_yoy,
                  "yoy_data_score_level":     process_group_score_yoy,
                  "inq_data":                 process_inquiry_index,
-                 "den_data":                 process_denial_index,
+                 "crt_data":                 process_tightness_index,
                  }
 
 


### PR DESCRIPTION
Changes "inferred denial index" and its related filenames, headers, etc, to "credit tightness index".

NOTE: Merging this will wipe out all draft content on any CCT page with a chart or a data snapshot block, so this is on HOLD pending publishing all our draft content.