### PR TITLE
Handle None when converting to JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 *.pyc
+.DS_Store
+.python-version

--- a/process_incoming_data.py
+++ b/process_incoming_data.py
@@ -251,7 +251,11 @@ def process_file_summary(filename, output_schema):
     """Processes specified summary file and outputs data per the schema"""
 
     # Load specified file as input data
-    inputdata = util.load_csv(filename)
+    try:
+        inputdata = util.load_csv(filename)
+    except Exception as e:
+        logger.error("Make sure you are running Python 2.x!".format(filename))
+        raise e
 
     # Process data
     proc = {}
@@ -584,6 +588,15 @@ def json_for_bar_chart(data):
                 "Ignore ValueError: Discard 'NA' and other non-float values"
             )
             continue
+        except TypeError as e:
+            logger.warn(
+                "Missing value as '{}' in row\n'{}'".format(
+                    row[2+colnum],
+                    repr(row)
+                )
+            )
+            # TODO: Raise error with data so filename can be determined
+            continue
 
     return {"Number of Loans": outnum, "Dollar Volume": outvol}
 
@@ -609,6 +622,15 @@ def json_for_group_bar_chart(data, val_cols, out_names):
                     "Ignore ValueError: Discard 'NA' and other " +
                     "non-float values"
                 )
+                continue
+            except TypeError as e:
+                logger.warn(
+                    "Missing value as '{}' in row\n'{}'".format(
+                        row[2+colnum],
+                        repr(row)
+                    )
+                )
+                # TODO: Raise error with data so filename can be determined
                 continue
 
     out = {}
@@ -639,6 +661,15 @@ def json_for_line_chart(data):
             logger.debug(
                 "Ignore ValueError: Discard 'NA' and other non-float values"
             )
+            continue
+        except TypeError as e:
+            logger.warn(
+                "Missing value as '{}' in row\n'{}'".format(
+                    row[2+colnum],
+                    repr(row)
+                )
+            )
+            # TODO: Raise error with data so filename can be determined
             continue
 
     return out
@@ -674,6 +705,15 @@ def json_for_group_line_chart(data):
             logger.debug(
                 "Ignore ValueError: Discard 'NA' and other non-float values"
             )
+            continue
+        except TypeError as e:
+            logger.warn(
+                "Missing value as '{}' in row\n'{}'".format(
+                    row[2+colnum],
+                    repr(row)
+                )
+            )
+            # TODO: Raise error with data so filename can be determined
             continue
 
     return out


### PR DESCRIPTION
Handle TypeError (on None values) when converting to JSON for graphs by omitting that point.

## Testing

- Pull down the latest GHE data
- Run the processing script with that data and notice a TypeError occurs
  - `python process_incoming_data.py -i ../consumer-credit-trends-data/data/ -o ~/Desktop/test/`
- Change to this branch
- Run and notice that instead of a TypeError, you receive a log warning:
  - `WARNING:__main__:Missing value as 'None' in row
'[218, '2018-02', None, '-0.14603307652991', '-0.125104162718098', '-0.0916499946196563', '-0.0315666643336828']'`

NOTE: If you get an error about `_csv.Error: iterator should return strings, not bytes (did you open the file in text mode?)`, make sure you're running Python 2.x. That error occurs when you're on Python 3.x