### PR TITLE
Python 3 compatibility

### DIFF
--- a/process_incoming_data.py
+++ b/process_incoming_data.py
@@ -814,7 +814,7 @@ def process_data_snapshot(filepath, date_schema=cfg.SNAPSHOT_DATE_SCHEMA):
             logger.error(msg)
             raise ValueError(msg)
 
-    return market_info.values()
+    return list(market_info.values())
 
 
 # Filenames are formatted as:

--- a/process_incoming_data.py
+++ b/process_incoming_data.py
@@ -88,7 +88,7 @@ def process_data_files(inputpath,
     )
 
     if len(inputfiles) == 0:
-        logger.warn("No csv data files found in {}".format(inputpath))
+        logger.warning("No csv data files found in {}".format(inputpath))
         return []
 
     successes = []
@@ -103,10 +103,10 @@ def process_data_files(inputpath,
         if market is None:
             if data_snapshot_fname in filename:
                 if len(data_snapshot_path) <= 0:
-                    logger.warn(
+                    logger.warning(
                         "Data snapshot output path is not specified."
                     )
-                    logger.warn(
+                    logger.warning(
                         "To process data snapshot file, specify " +
                         "the --data-snapshot-path command-line " +
                         "argument."
@@ -181,7 +181,7 @@ def process_data_files(inputpath,
     )
 
     if len(failures) > 0:
-        logger.warn(
+        logger.warning(
             "** Unable to process {} input data files".format(
                 len(failures)
             )
@@ -589,7 +589,7 @@ def json_for_bar_chart(data):
             )
             continue
         except TypeError as e:
-            logger.warn(
+            logger.warning(
                 "Missing value as '{}' in row\n'{}'".format(
                     row[2+colnum],
                     repr(row)
@@ -624,7 +624,7 @@ def json_for_group_bar_chart(data, val_cols, out_names):
                 )
                 continue
             except TypeError as e:
-                logger.warn(
+                logger.warning(
                     "Missing value as '{}' in row\n'{}'".format(
                         row[2+colnum],
                         repr(row)
@@ -663,7 +663,7 @@ def json_for_line_chart(data):
             )
             continue
         except TypeError as e:
-            logger.warn(
+            logger.warning(
                 "Missing value as '{}' in row\n'{}'".format(
                     row[2+colnum],
                     repr(row)
@@ -707,7 +707,7 @@ def json_for_group_line_chart(data):
             )
             continue
         except TypeError as e:
-            logger.warn(
+            logger.warning(
                 "Missing value as '{}' in row\n'{}'".format(
                     row[2+colnum],
                     repr(row)

--- a/process_utils.py
+++ b/process_utils.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 # Utility Methods
 
-def save_csv(filename, content, writemode='wb'):
+def save_csv(filename, content, writemode='w'):
     """Saves the specified content object into a csv file."""
     if not os.path.exists(os.path.dirname(filename)):
         os.makedirs(os.path.dirname(filename))
@@ -52,7 +52,7 @@ def save_csv(filename, content, writemode='wb'):
     logger.debug("Wrote file '{}'".format(filename))
 
 
-def save_json(filename, json_content, writemode='wb'):
+def save_json(filename, json_content, writemode='w'):
     """Dumps the specified JSON content into a .json file"""
     if not os.path.exists(os.path.dirname(filename)):
         os.makedirs(os.path.dirname(filename))
@@ -70,9 +70,9 @@ def save_json(filename, json_content, writemode='wb'):
     logger.debug("Wrote file '{}'".format(filename))
 
 
-def load_csv(filename, skipheaderrow=True):
+def load_csv(filename, readmode='r', skipheaderrow=True):
     """Loads CSV data from a file"""
-    with open(filename, 'rb') as csvfile:
+    with open(filename, readmode) as csvfile:
         reader = csv.reader(csvfile)
         data = list(reader)
 

--- a/process_utils.py
+++ b/process_utils.py
@@ -62,10 +62,13 @@ def save_json(filename, json_content, writemode='w'):
 
     # Write output as a json file
     with open(filename, writemode) as fp:
-        fp.write(json.dumps(json_content,
-                            sort_keys=True,
-                            indent=4,
-                            separators=(',', ': ')))
+        json.dump(
+            json_content,
+            fp,
+            sort_keys=True,
+            indent=4,
+            separators=(',', ': ')
+        )
 
     logger.debug("Wrote file '{}'".format(filename))
 


### PR DESCRIPTION
Previously, using Python 3.x would cause massive breakage, despite the bulk of the code being 3.x compatible already. I've made a number of changes to mainly the read/write portion to support both Python 2.x and 3.x now.

## Changes

- Updates readers/writers to non-binary mode
- Updates data snapshot to using a list instead of unserializable `dict_values` type object
- Changes from using `dumps()` and a file writer to using `dump()` directly into the file pointer
- Per a deprecation notice, converted `logger.warn()` calls to `logger.warning()`

## Testing

1. Run the processing script using Python 2.x (pyenv recommended)
1. Run the processing script using Python 3.x
    - Notice that there are no error notices or stack traces
    - If desired, diff the results from both pythons to verify files are identical