### PR TITLE
Fix to json_for_bar_chart to remove reference to undefined variable row

### DIFF
--- a/process_incoming_data.py
+++ b/process_incoming_data.py
@@ -590,9 +590,9 @@ def json_for_bar_chart(data):
             continue
         except TypeError as e:
             logger.warning(
-                "Missing value as '{}' in row\n'{}'".format(
-                    row[2+colnum],
-                    repr(row)
+                "Missing value as '{}' in data\n'{}'".format(
+                    yoy_num,
+                    repr(data)
                 )
             )
             # TODO: Raise error with data so filename can be determined


### PR DESCRIPTION
There is a function called json_for_bar_chart in processing_incoming_data.py.

A variable data is passed into this function, array variables outnum and outvol are defined.

There is a for loop that extracts the following from the data variable:
month, date, yoy_num, yoy_vol

yoy_num gets appended to outnum and you_vol gets appended to outval in a try block.

if there is a TypeError exception a logger.warning is raised.

However this warning uses a variable row which is not defined anywhere in json_for_bar_chart.

I made two small changes:
1. replaced the row variable with the data variable
2. replaced row[2+colnum] with yoy_num

I would appreciate someone who knows the code to confirm the above variable substitution is correct.

$ python ../consumer-credit-trends-data-public/process_incoming_data.py -i ./data/ -o ~/Desktop/consumer-credit-trends-data/

INFO:__main__:Found 88 csv files in 'consumer-credit-trends-data/data'
Traceback (most recent call last):
  File "../consumer-credit-trends-data-public/process_incoming_data.py", line 882, in <module>
    data_snapshot_path=args.output_data_snapshot_file
  File "../consumer-credit-trends-data-public/process_incoming_data.py", line 159, in process_data_files
    cond, data, json = FILE_PREFIXES[current_prefix](filepath)
  File "../consumer-credit-trends-data-public/process_incoming_data.py", line 568, in process_yoy_summary
    json = json_for_bar_chart(data[1:])
  File "../consumer-credit-trends-data-public/process_incoming_data.py", line 594, in json_for_bar_chart
    row[2+colnum],
**NameError: global name 'row' is not defined**