### PR TITLE
Add ZScaler public cert to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,16 @@ RUN adduser -g ${USERNAME} --disabled-password ${USERNAME}
 
 WORKDIR ${HOME}
 
+# Add Zscaler Root CA certificate and rebuild CA certificates
+ADD https://raw.githubusercontent.com/cfpb/zscaler-cert/3982ebd9edf9de9267df8d1732ff5a6f88e38375/zscaler_root_ca.pem ${HOME}/zscaler-root-public.cert
+RUN cp ${HOME}/zscaler-root-public.cert /usr/local/share/ca-certificates/zscaler-root-public.cert && \
+    apk add ca-certificates --no-cache --no-check-certificate && \
+    update-ca-certificates
+
 RUN apk update --no-cache && \
     apk upgrade --no-cache && \
     apk add --no-cache git && \
     pip install --upgrade pip setuptools
-
 
 COPY process_globals.py .
 COPY process_utils.py .


### PR DESCRIPTION
This adds the public ZScaler root certificate to the Dockerfile based on @contolini's docs [in the repo we're pulling the cert from](https://github.com/cfpb/zscaler-cert) and following [HMDA](cfpb/hmda-frontend#2665) and [cf.gov](https://github.com/cfpb/consumerfinance.gov/pull/8995)'s examples.